### PR TITLE
Add tests for two argument open and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This policy has no affiliation
 
 # DESCRIPTION
 
-This policy addresses an anti-pattern and possible bug. If you use 3-argument `open` combinted with the high precedence logical or operator `||` for error handling.
+This policy addresses an anti-pattern and possible bug. If you use `open` combined with the high precedence logical or operator `||` for error handling.
 
-If the file parameter is pointing to a non-existant file, the use of a high precedence logical operator `||`, does not short-cut as expected. This implies that the bug only is present if the file does not exist. If the file exist, but cannot be opened the error handling is not working as expected.
+If the file parameter is pointing to a non-existent file, the use of a high precedence logical operator `||`, does not short-cut as expected. This implies that the bug only is present if the file does not exist. If the file exists, but cannot be opened the error handling is not working as expected.
 
     open my $fh, '<', $file
             || die "Can't open '$file': $!"; # not okay
@@ -25,7 +25,16 @@ If the file parameter is pointing to a non-existant file, the use of a high prec
     open my $fh, '<', $file
         or die "Can't open '$file': $!"; # okay
 
-The remedy is to use parentheses for `open` or the lower precendedence logical operator `or`.
+    open my $fh, "<$file"
+            || die "Can't open '$file': $!"; # not okay
+
+    open(my $fh, "<$file")
+        || die "Can't open '$file': $!"; # okay
+
+    open my $fh, "<$file"
+        or die "Can't open '$file': $!"; # okay
+
+The remedy is to use parentheses for `open` or the lower precedence logical operator `or`.
 
 Alternatively [autodie](https://metacpan.org/pod/autodie) can be used,
 

--- a/lib/Perl/Critic/Policy/InputOutput/ProhibitHighPrecedentLogicalOperatorErrorHandling.pm
+++ b/lib/Perl/Critic/Policy/InputOutput/ProhibitHighPrecedentLogicalOperatorErrorHandling.pm
@@ -83,9 +83,9 @@ This policy has no affiliation
 
 =head1 DESCRIPTION
 
-This policy addresses an anti-pattern and possible bug. If you use 3-argument C<open> combinted with the high precedence logical or operator C<||> for error handling.
+This policy addresses an anti-pattern and possible bug. If you use C<open> combined with the high precedence logical or operator C<||> for error handling.
 
-If the file parameter is pointing to a non-existant file, the use of a high precedence logical operator C<||>, does not short-cut as expected. This implies that the bug only is present if the file does not exist. If the file exist, but cannot be opened the error handling is not working as expected.
+If the file parameter is pointing to a non-existent file, the use of a high precedence logical operator C<||>, does not short-cut as expected. This implies that the bug only is present if the file does not exist. If the file exists, but cannot be opened the error handling is not working as expected.
 
     open my $fh, '<', $file
             || die "Can't open '$file': $!"; # not okay
@@ -96,7 +96,16 @@ If the file parameter is pointing to a non-existant file, the use of a high prec
     open my $fh, '<', $file
         or die "Can't open '$file': $!"; # okay
 
-The remedy is to use parentheses for C<open> or the lower precendedence logical operator C<or>.
+    open my $fh, "<$file"
+            || die "Can't open '$file': $!"; # not okay
+
+    open(my $fh, "<$file")
+        || die "Can't open '$file': $!"; # okay
+
+    open my $fh, "<$file"
+        or die "Can't open '$file': $!"; # okay
+
+The remedy is to use parentheses for C<open> or the lower precedence logical operator C<or>.
 
 Alternatively L<autodie|https://metacpan.org/pod/autodie> can be used,
 

--- a/t/test.t
+++ b/t/test.t
@@ -78,4 +78,64 @@ my $critic = Perl::Critic->new(
     is( scalar @violations, 0 );
 }
 
+# The bug with two-arg open
+{
+    my $str = q[
+        open my $fh, "<$file"
+            || die "Can't open '$file': $!";
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 1 );
+}
+
+# No bug - with parenthesis
+{
+    my $str = q[
+        open(my $fh, "<$file")
+            || die "Can't open '$file': $!";
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
+}
+
+# No bug - with or
+{
+    my $str = q[
+        open my $fh, "<$file"
+            or die "Can't open '$file': $!";
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
+}
+
+# No bug - with or and parenthesis
+{
+    my $str = q[
+        open(my $fh, "<$file")
+            or die "Can't open '$file': $!";
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
+}
+
+# No bug - with or and parenthesis and whitespace
+{
+    my $str = q[
+        open ( my $fh, "<$file" )
+            || die "Can't open '$file': $!";
+    ];
+
+    my @violations = $critic->critique( \$str );
+
+    is( scalar @violations, 0 );
+}
+
 exit 0;

--- a/t/test.t
+++ b/t/test.t
@@ -27,7 +27,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 1 );
+    is( scalar @violations, 1, 'The bug' );
 }
 
 # No bug - with parenthesis
@@ -39,7 +39,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with parenthesis');
 }
 
 # No bug - with or
@@ -51,7 +51,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or');
 }
 
 # No bug - with or and parenthesis
@@ -63,7 +63,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or and parenthesis');
 }
 
 # No bug - with or and parenthesis and whitespace
@@ -75,7 +75,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or and parenthesis and whitespace');
 }
 
 # The bug with two-arg open
@@ -87,7 +87,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 1 );
+    is( scalar @violations, 1, 'Two-arg open bug');
 }
 
 # No bug - with parenthesis
@@ -99,7 +99,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with parenthesis');
 }
 
 # No bug - with or
@@ -111,7 +111,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or');
 }
 
 # No bug - with or and parenthesis
@@ -123,7 +123,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or and parenthesis');
 }
 
 # No bug - with or and parenthesis and whitespace
@@ -135,7 +135,7 @@ my $critic = Perl::Critic->new(
 
     my @violations = $critic->critique( \$str );
 
-    is( scalar @violations, 0 );
+    is( scalar @violations, 0, 'No bug - with or and parenthesis and whitespace');
 }
 
 exit 0;


### PR DESCRIPTION
# Description

Please include a summary of the proposed improvement or addressed issue.

Added tests for two-argument `open || die`, and updated documentation.

Fixes/addresses (If applicable) #3 (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-date-holidays/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
  The tests I added cause "Literal line breaks in a string" warnings with `perlcritic --top t/test.t`
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
